### PR TITLE
Updated build.xml to include class optimizer in smallJar build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -114,11 +114,15 @@
       <include name="org/mozilla/javascript/annotations/*.class"/>
       <include name="org/mozilla/javascript/v8dtoa/*.class"/>
 
+      <include name="org/mozilla/classfile/*.class" if="${optimizer}"/>
+      <include name="org/mozilla/javascript/tools/jsc/*.class" if="${optimizer}"/>
+      <include name="org/mozilla/javascript/optimizer/*.class" if="${optimizer}"/>
+      <include name="org/mozilla/javascript/tools/*.class" if="${optimizer}"/>
       <!-- exclude classes that uses class generation library -->
-      <exclude name="org/mozilla/javascript/JavaAdapter*.class"/>
+      <exclude name="org/mozilla/javascript/JavaAdapter*.class" unless="${optimizer}"/>
 
       <include name="org/mozilla/javascript/regexp/*.class"
-               unless="no-regexp"/>
+               unless="${no-regexp}"/>
     </jar>
   </target>
 


### PR DESCRIPTION
My need was to include Optimizer classes but I wanted to avoid tools. Updated build.xml and added a optimizer attribute in the smallJar build command.

**Current Support :**

ant clean
ant -Ddebug=off -Dno-regexp=true -Dno-e4x=true smalljar

**When optimizer classes are need with small footprint :**

ant clean
ant -Ddebug=off -Dno-regexp=true -Dno-e4x=true -Doptimizer=true smalljar
